### PR TITLE
GH-86: Setup GraphQL Data Layer

### DIFF
--- a/components/countries-table.tsx
+++ b/components/countries-table.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { useQuery, gql } from '@apollo/client'
+import { Text, Table, Thead, Tbody, Th, Tr, Td } from '@chakra-ui/react'
+
+type CountriesTableProps = Record<string, never>
+
+type Country = {
+  code: string
+  name: string
+  emoji: string
+}
+
+const QUERY = gql`
+  query Countries {
+    countries(filter: { continent: { eq: "EU" } }) {
+      code
+      name
+      emoji
+    }
+  }
+`
+
+export const CountriesTable: React.FC<CountriesTableProps> = () => {
+  const { data, loading, error } = useQuery<{ countries: Country[] }>(QUERY)
+
+  if (error) {
+    console.error(error)
+    return <Text color="red">{error.message}</Text>
+  }
+
+  if (loading) {
+    return <Text>loading...</Text>
+  }
+
+  return (
+    <Table id="countries-table">
+      <Thead>
+        <Tr>
+          <Th>Code</Th>
+          <Th>Name</Th>
+          <Th>Emoji</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data?.countries.slice(0, 10).map((country) => (
+          <Tr key={country.code}>
+            <Td>{country.code}</Td>
+            <Td>{country.name}</Td>
+            <Td>{country.emoji}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  )
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,2 @@
+export * from './countries-table'
+export * from './metric-table'

--- a/components/metric-table.tsx
+++ b/components/metric-table.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { useQuery, gql } from '@apollo/client'
+import { Text, Table, Thead, Tbody, Th, Tr, Td } from '@chakra-ui/react'
+
+type MetricTableProps = Record<never, never>
+
+type Metric = {
+  id: string
+  name: string
+  value: number
+}
+
+const QUERY = gql`
+  query Metrics {
+    metrics {
+      id
+      name
+      value
+    }
+  }
+`
+
+export const MetricTable: React.FC<MetricTableProps> = () => {
+  const { data, loading, error } = useQuery<{ metrics: Metric[] }>(QUERY)
+
+  if (error) {
+    console.error(error)
+    return <Text color="red">{error.message}</Text>
+  }
+
+  if (loading) {
+    return <Text>loading...</Text>
+  }
+
+  return (
+    <Table id="metrics-table">
+      <Thead>
+        <Tr>
+          <Th>Id</Th>
+          <Th>Name</Th>
+          <Th>Value</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data?.metrics.map((metric) => (
+          <Tr key={metric.id}>
+            <Td>{metric.id}</Td>
+            <Td>{metric.name}</Td>
+            <Td>{metric.value}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  )
+}

--- a/cypress/integration/pages/countries.spec.js
+++ b/cypress/integration/pages/countries.spec.js
@@ -1,0 +1,41 @@
+describe('/countries', () => {
+  beforeEach(() => {
+    cy.visit('/countries')
+  })
+
+  describe('countries table', () => {
+    beforeEach(() => {
+      cy.get('#countries-table').as('countries-table')
+    })
+
+    describe('header', () => {
+      beforeEach(() => {
+        cy.get('@countries-table').children('thead').as('table-header')
+      })
+
+      it('should have expected headers', () => {
+        cy.get('@table-header').contains('th', 'Code')
+        cy.get('@table-header').contains('th', 'Name')
+        cy.get('@table-header').contains('th', 'Emoji')
+      })
+    })
+
+    describe('body', () => {
+      beforeEach(() => {
+        cy.get('@countries-table').children('tbody').as('table-body')
+      })
+
+      it('should have multiple rows', () => {
+        cy.get('@table-body').children('tr').should('have.length.gte', 2)
+      })
+
+      it('should populate all cells', () => {
+        cy.get('@table-body')
+          .find('td')
+          .each(($td) => {
+            cy.wrap($td).invoke('text').should('not.be.empty')
+          })
+      })
+    })
+  })
+})

--- a/cypress/integration/pages/metrics.spec.js
+++ b/cypress/integration/pages/metrics.spec.js
@@ -1,0 +1,41 @@
+describe('/metrics', () => {
+  beforeEach(() => {
+    cy.visit('/metrics')
+  })
+
+  describe('metrics table', () => {
+    beforeEach(() => {
+      cy.get('#metrics-table').as('metrics-table')
+    })
+
+    describe('header', () => {
+      beforeEach(() => {
+        cy.get('@metrics-table').children('thead').as('table-header')
+      })
+
+      it('should have expected headers', () => {
+        cy.get('@table-header').contains('th', 'Id')
+        cy.get('@table-header').contains('th', 'Name')
+        cy.get('@table-header').contains('th', 'Value')
+      })
+    })
+
+    describe('body', () => {
+      beforeEach(() => {
+        cy.get('@metrics-table').children('tbody').as('table-body')
+      })
+
+      it('should have multiple rows', () => {
+        cy.get('@table-body').children('tr').should('have.length.gte', 2)
+      })
+
+      it('should populate all cells', () => {
+        cy.get('@table-body')
+          .find('td')
+          .each(($td) => {
+            cy.wrap($td).invoke('text').should('not.be.empty')
+          })
+      })
+    })
+  })
+})

--- a/graphql/client.ts
+++ b/graphql/client.ts
@@ -1,0 +1,6 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client'
+
+export const client = new ApolloClient({
+  uri: '/api/graphql',
+  cache: new InMemoryCache(),
+})

--- a/graphql/schema/countries.ts
+++ b/graphql/schema/countries.ts
@@ -1,0 +1,21 @@
+import { AsyncExecutor } from '@graphql-tools/utils'
+import { introspectSchema } from '@graphql-tools/wrap'
+import { print } from 'graphql'
+
+const remoteExecutor: AsyncExecutor = async ({ document, variables }) => {
+  const query = print(document)
+  const fetchResult = await fetch('https://countries.trevorblades.com/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  })
+
+  /* eslint-disable @typescript-eslint/no-unsafe-return */
+  return fetchResult.json()
+  /* eslint-enable @typescript-eslint/no-unsafe-return */
+}
+
+export const getCountriesSchema = async () => ({
+  schema: await introspectSchema(remoteExecutor),
+  executor: remoteExecutor,
+})

--- a/graphql/schema/index.ts
+++ b/graphql/schema/index.ts
@@ -1,0 +1,10 @@
+import { stitchSchemas } from '@graphql-tools/stitch'
+
+import metricsSchema from './metrics'
+
+import { getCountriesSchema } from './countries'
+
+export const buildSchema = async () =>
+  stitchSchemas({
+    subschemas: [metricsSchema, await getCountriesSchema()],
+  })

--- a/graphql/schema/metrics.ts
+++ b/graphql/schema/metrics.ts
@@ -1,0 +1,35 @@
+import { gql } from 'apollo-server-express'
+import { makeExecutableSchema } from '@graphql-tools/schema'
+
+const typeDefs = gql`
+  type Metric {
+    id: ID!
+    name: String!
+    value: Float!
+  }
+
+  type Query {
+    """
+    Fetch mocked metrics.
+    """
+    metrics: [Metric!]!
+  }
+`
+
+const resolvers = {
+  Metric: {
+    value: (metric: any) => Math.random() * metric.maxValue,
+  },
+  Query: {
+    metrics: () => [
+      { id: '01', name: 'speed', maxValue: 100 },
+      { id: '02', name: 'mpg', maxValue: 40 },
+      { id: '03', name: 'rpm', maxValue: 10_000 },
+    ],
+  },
+}
+
+export default makeExecutableSchema({
+  typeDefs,
+  resolvers,
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,72 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.6.tgz",
+      "integrity": "sha512-XHoouuEJ4L37mtfftcHHO1caCRrKKAofAwqRoq28UQIPMJk+e7n3X9OtRRNXKk/9tmhNkwelSary+EilfPwI7A==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.4",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@apollo/protobufjs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
+      }
+    },
+    "@apollographql/apollo-tools": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.2.tgz",
+      "integrity": "sha512-KxZiw0Us3k1d0YkJDhOpVH5rJ+mBfjXcgoRoCcslbgirjgLotKMzOcx4PZ7YTEvvEROmvG7X3Aon41GvMmyGsw=="
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.29",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
+      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
+      "requires": {
+        "xss": "^1.0.8"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.15.8",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
@@ -1337,6 +1403,174 @@
         }
       }
     },
+    "@graphql-tools/batch-delegate": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-8.2.3.tgz",
+      "integrity": "sha512-0205ujghXof7ZsKuBkhGJgie46ZKV4BSShWD4HI4H2O+5WSVzR/n5+jAl/KIMmJ9HomwxfXlYYfBHWTcIQ8s7g==",
+      "requires": {
+        "@graphql-tools/delegate": "^8.4.3",
+        "@graphql-tools/utils": "^8.5.4",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/batch-execute": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
+      "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
+      "requires": {
+        "@graphql-tools/utils": "^8.5.1",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
+      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
+      "requires": {
+        "@graphql-tools/batch-execute": "^8.3.1",
+        "@graphql-tools/schema": "^8.3.1",
+        "@graphql-tools/utils": "^8.5.4",
+        "dataloader": "2.0.0",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.1.tgz",
+      "integrity": "sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==",
+      "requires": {
+        "@graphql-tools/utils": "^8.5.1",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/mock": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.5.0.tgz",
+      "integrity": "sha512-J4HZFPT78RbVFpm/yqY/1UeDVkvXQW6RMxZbOlV9xpC4ufFw/AzUlBnaXKhWgkRgIPf7RZZidahoz1W+dt/Juw==",
+      "requires": {
+        "@graphql-tools/schema": "^8.3.1",
+        "@graphql-tools/utils": "^8.5.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.1.tgz",
+      "integrity": "sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==",
+      "requires": {
+        "@graphql-tools/merge": "^8.2.1",
+        "@graphql-tools/utils": "^8.5.1",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/stitch": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-8.4.3.tgz",
+      "integrity": "sha512-IOgKgMu/TeB0ZHOFHW147I/9LUo4NgRs7vqTqmTPVutiTR1YPYDdBWoQh+rhDBQN6gvxKq6EI/RcMGslbOMLvQ==",
+      "requires": {
+        "@graphql-tools/batch-delegate": "8.2.3",
+        "@graphql-tools/delegate": "^8.4.3",
+        "@graphql-tools/merge": "^8.2.1",
+        "@graphql-tools/schema": "^8.3.1",
+        "@graphql-tools/utils": "^8.5.4",
+        "@graphql-tools/wrap": "^8.3.1",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.5.tgz",
+      "integrity": "sha512-y7zRXWIUI73X+9/rf/0KzrNFMlpRKFfzLiwdbIeWwgLs+NV9vfUOoVkX8luXX6LwQxhSypHATMiwZGM2ro/wJA==",
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/wrap": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.2.tgz",
+      "integrity": "sha512-7DcOBFB+Dd84x9dxSm7qS4iJONMyfLnCJb8A19vGPffpu4SMJ3sFcgwibKFu5l6mMUiigKgXna2RRgWI+02bKQ==",
+      "requires": {
+        "@graphql-tools/delegate": "^8.4.2",
+        "@graphql-tools/schema": "^8.3.1",
+        "@graphql-tools/utils": "^8.5.3",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg=="
+    },
     "@hapi/accept": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
@@ -1706,6 +1940,11 @@
         "chalk": "^4.0.0"
       }
     },
+    "@josephg/resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
+    },
     "@napi-rs/triples": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
@@ -1916,6 +2155,60 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.0.tgz",
       "integrity": "sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ=="
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@reach/alert": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@reach/alert/-/alert-0.13.2.tgz",
@@ -1997,6 +2290,14 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.17",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.17.tgz",
@@ -2038,6 +2339,28 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -2053,6 +2376,27 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.27",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz",
+      "integrity": "sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -2122,6 +2466,16 @@
         "@types/lodash": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -2129,9 +2483,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ=="
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
+      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2156,6 +2510,25 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/ramda": {
+      "version": "0.27.62",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.62.tgz",
+      "integrity": "sha512-/s4yTNOk8YXZ2Ys8OqSPmExyWxuKQMCDwjyVowg0RW6F45SlSGSI0sduyhx7RREASowlVJppAvR4KRqMzJnu2g==",
+      "dev": true,
+      "requires": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
     "@types/react": {
       "version": "17.0.38",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
@@ -2172,6 +2545,15 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.4",
@@ -2417,11 +2799,65 @@
         }
       }
     },
+    "@wry/context": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
     },
     "acorn": {
       "version": "8.5.0",
@@ -2531,6 +2967,108 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apollo-datasource": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.0.tgz",
+      "integrity": "sha512-It8POTZTOCAnedRj2izEVeySN06LIfojigZjWaOY7voLe0DIgtvhql91xr27fuIWsR/Ew9twO3dLBjjvy34J4Q==",
+      "requires": {
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0"
+      }
+    },
+    "apollo-reporting-protobuf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.0.tgz",
+      "integrity": "sha512-51Jwrg0NvHJfKz7TIGU8+Os3rUAqWtXeKRsRtKYtTeMSBPNhzz8UoGjAB3XyVmUXRE3IRmLtDPDRFL7qbxMI/w==",
+      "requires": {
+        "@apollo/protobufjs": "1.2.2"
+      }
+    },
+    "apollo-server-caching": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "apollo-server-core": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.6.1.tgz",
+      "integrity": "sha512-V2Us5x7d+w8dVdyFLxEygMgaQ3KZ6Z59HpaQBNHQ7C5wVZhjUXIsgbehBtfzQbMpyMx0z5/8Z8eIrC4zNoGJDw==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.5.1",
+        "@apollographql/graphql-playground-html": "1.6.29",
+        "@graphql-tools/mock": "^8.1.2",
+        "@graphql-tools/schema": "^8.0.0",
+        "@graphql-tools/utils": "^8.0.0",
+        "@josephg/resolvable": "^1.0.0",
+        "apollo-datasource": "^3.3.0",
+        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0",
+        "apollo-server-errors": "^3.3.0",
+        "apollo-server-plugin-base": "^3.5.0",
+        "apollo-server-types": "^3.5.0",
+        "async-retry": "^1.2.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graphql-tag": "^2.11.0",
+        "lodash.sortby": "^4.7.0",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^6.0.0",
+        "sha.js": "^2.4.11",
+        "uuid": "^8.0.0"
+      }
+    },
+    "apollo-server-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.0.tgz",
+      "integrity": "sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==",
+      "requires": {
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "apollo-server-errors": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.0.tgz",
+      "integrity": "sha512-9/MNlPZBbEjcCdJcUSbKbVEBT9xZS8GSpX7T/TyzcxHSbsXJszSDSipQNGC+PRKTKAUnv61IONScVyLKEZ5XEQ=="
+    },
+    "apollo-server-express": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.6.1.tgz",
+      "integrity": "sha512-29imWvRPn5GsQq02Akt0+jejpWzpOIZfUmgoiFm4YB7somvhDNw15Pu7fv4sISK8ehNIDF68IpLd2cpY8sCkYQ==",
+      "requires": {
+        "@types/accepts": "^1.3.5",
+        "@types/body-parser": "1.19.2",
+        "@types/cors": "2.8.12",
+        "@types/express": "4.17.13",
+        "@types/express-serve-static-core": "4.17.27",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^3.6.1",
+        "apollo-server-types": "^3.5.0",
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "parseurl": "^1.3.3"
+      }
+    },
+    "apollo-server-plugin-base": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.0.tgz",
+      "integrity": "sha512-dpi+W6wexT4H3cjIhxC9SJABkR8TCfxycoHK+U4jxQXUdg50da+KnMgoWlQbF1tuXtUs4gnJtij1RjuGtKwBhw==",
+      "requires": {
+        "apollo-server-types": "^3.5.0"
+      }
+    },
+    "apollo-server-types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.0.tgz",
+      "integrity": "sha512-4JaZNu1kjrzIbppgc78hhIe2DFe+XONf8grprcjTOe0v8dIsuV0tFUnl+awTvTpHU1sdjRCKwnj382BebiL+qw==",
+      "requires": {
+        "apollo-reporting-protobuf": "^3.3.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0"
+      }
+    },
     "arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -2569,6 +3107,11 @@
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
       "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
       "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
       "version": "3.1.4",
@@ -2678,6 +3221,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
       "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2891,6 +3442,81 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+    },
+    "body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "requires": {
+        "bytes": "3.1.1",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
+        "type-is": "~1.6.18"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+        },
+        "raw-body": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+          "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+          "requires": {
+            "bytes": "3.1.1",
+            "http-errors": "1.8.1",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        },
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3357,6 +3983,26 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3364,6 +4010,16 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-to-clipboard": {
       "version": "3.3.1",
@@ -3384,6 +4040,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -3480,6 +4145,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssnano-preset-simple": {
       "version": "3.0.0",
@@ -3654,6 +4324,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "dayjs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
@@ -3762,6 +4437,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3846,6 +4526,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "electron-to-chromium": {
       "version": "1.4.12",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.12.tgz",
@@ -3888,6 +4573,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.13",
@@ -4005,6 +4695,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "2.0.0",
@@ -4967,6 +5662,73 @@
         }
       }
     },
+    "express": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.6",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5030,8 +5792,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5098,6 +5859,35 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "find-cache-dir": {
@@ -5178,6 +5968,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
     "framer-motion": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-5.5.5.tgz",
@@ -5237,6 +6032,11 @@
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -5441,6 +6241,26 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+    },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -5731,6 +6551,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irregular-plurals": {
       "version": "3.3.0",
@@ -6071,6 +6896,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -7523,6 +8357,16 @@
         }
       }
     },
+    "loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7541,7 +8385,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7584,6 +8427,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memory-fs": {
       "version": "0.2.0",
@@ -7709,6 +8557,11 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7719,6 +8572,11 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micro-spelling-correcter": {
       "version": "1.1.1",
@@ -7752,17 +8610,20 @@
         }
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
     "mime-db": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "dev": true
+      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A=="
     },
     "mime-types": {
       "version": "2.1.33",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
       "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "dev": true,
       "requires": {
         "mime-db": "1.50.0"
       }
@@ -7844,6 +8705,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "next": {
       "version": "12.0.7",
@@ -8179,6 +9045,14 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8226,6 +9100,15 @@
         "execa": "^5.1.1",
         "line-column-path": "^3.0.0",
         "open": "^8.4.0"
+      }
+    },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optionator": {
@@ -8325,6 +9208,11 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -8351,6 +9239,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "4.0.0",
@@ -8559,6 +9452,15 @@
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -8643,6 +9545,11 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8659,6 +9566,11 @@
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.1",
@@ -8936,6 +9848,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9033,6 +9950,81 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        },
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -9447,6 +10439,11 @@
         "supports-color": "^7.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -9591,6 +10588,21 @@
       "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
       "dev": true
     },
+    "ts-invariant": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
+      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "ts-jest": {
       "version": "27.1.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
@@ -9617,6 +10629,12 @@
           }
         }
       }
+    },
+    "ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.11.0",
@@ -9702,6 +10720,15 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -9733,6 +10760,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -9818,11 +10850,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -9858,6 +10894,16 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
@@ -10045,15 +11091,15 @@
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.4",
-        "@typescript-eslint/eslint-plugin": "*",
-        "@typescript-eslint/parser": "*",
+        "@typescript-eslint/eslint-plugin": "^5.4.0",
+        "@typescript-eslint/parser": "^5.4.0",
         "arrify": "^3.0.0",
         "cosmiconfig": "^7.0.1",
         "define-lazy-prop": "^3.0.0",
         "eslint": "^8.3.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-xo": "^0.39.0",
-        "eslint-config-xo-typescript": "*",
+        "eslint-config-xo-typescript": "^0.47.1",
         "eslint-formatter-pretty": "^4.1.0",
         "eslint-import-resolver-webpack": "^0.13.2",
         "eslint-plugin-ava": "^13.1.0",
@@ -10084,7 +11130,7 @@
       "dependencies": {
         "@nodelib/fs.scandir": {
           "version": "2.1.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "2.0.5",
@@ -10093,12 +11139,12 @@
         },
         "@nodelib/fs.stat": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@nodelib/fs.walk": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.scandir": "2.1.5",
@@ -10107,12 +11153,12 @@
         },
         "@types/json-schema": {
           "version": "7.0.9",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/experimental-utils": "5.4.0",
@@ -10127,14 +11173,14 @@
           "dependencies": {
             "ignore": {
               "version": "5.1.9",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "@typescript-eslint/experimental-utils": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
@@ -10147,7 +11193,7 @@
         },
         "@typescript-eslint/parser": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.4.0",
@@ -10158,7 +11204,7 @@
         },
         "@typescript-eslint/scope-manager": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.4.0",
@@ -10167,12 +11213,12 @@
         },
         "@typescript-eslint/types": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.4.0",
@@ -10186,12 +11232,12 @@
           "dependencies": {
             "array-union": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "globby": {
               "version": "11.0.4",
-              "bundled": true,
+              "resolved": false,
               "dev": true,
               "requires": {
                 "array-union": "^2.1.0",
@@ -10204,19 +11250,19 @@
             },
             "ignore": {
               "version": "5.1.9",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             },
             "slash": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "@typescript-eslint/visitor-keys": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.4.0",
@@ -10225,7 +11271,7 @@
         },
         "braces": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
@@ -10233,7 +11279,7 @@
         },
         "debug": {
           "version": "4.3.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -10241,14 +11287,14 @@
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "dir-glob": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "path-type": "^4.0.0"
@@ -10265,7 +11311,7 @@
         },
         "eslint-config-xo-typescript": {
           "version": "0.47.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "eslint-plugin-import": {
@@ -10302,7 +11348,7 @@
         },
         "eslint-scope": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -10311,14 +11357,14 @@
           "dependencies": {
             "estraverse": {
               "version": "4.3.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "eslint-utils": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
@@ -10326,19 +11372,19 @@
           "dependencies": {
             "eslint-visitor-keys": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
               "dev": true
             }
           }
         },
         "eslint-visitor-keys": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "esrecurse": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "estraverse": "^5.2.0"
@@ -10346,12 +11392,12 @@
         },
         "estraverse": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "fast-glob": {
           "version": "3.2.7",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -10363,7 +11409,7 @@
         },
         "fastq": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "reusify": "^1.0.4"
@@ -10371,7 +11417,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
@@ -10389,12 +11435,12 @@
         },
         "functional-red-black-tree": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "glob-parent": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -10411,12 +11457,12 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "is-glob": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -10424,7 +11470,7 @@
         },
         "is-number": {
           "version": "7.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "locate-path": {
@@ -10438,7 +11484,7 @@
         },
         "lru-cache": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -10446,12 +11492,12 @@
         },
         "merge2": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "micromatch": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "braces": "^3.0.1",
@@ -10490,32 +11536,32 @@
         },
         "path-type": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "picomatch": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "queue-microtask": {
           "version": "1.2.3",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "regexpp": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "reusify": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "run-parallel": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "queue-microtask": "^1.2.2"
@@ -10523,7 +11569,7 @@
         },
         "semver": {
           "version": "7.3.5",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -10537,7 +11583,7 @@
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "is-number": "^7.0.0"
@@ -10545,12 +11591,12 @@
         },
         "tslib": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "tsutils": {
           "version": "3.21.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"
@@ -10558,7 +11604,7 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "dev": true
         },
         "yocto-queue": {
@@ -10566,6 +11612,22 @@
           "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
           "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
           "dev": true
+        }
+      }
+    },
+    "xss": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.10.tgz",
+      "integrity": "sha512-qmoqrRksmzqSKvgqzN0055UFWY7OKx1/9JWeRswwEVX9fCG5jcYRxa/A2DHcmZX6VJvjzHRQ2STeeVcQkrmLSw==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         }
       }
     },
@@ -10583,8 +11645,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",
@@ -10626,6 +11687,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
+      "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
+      "requires": {
+        "zen-observable": "0.8.15"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@types/jest": "27.4.0",
+    "@types/node": "17.0.5",
+    "@types/ramda": "0.27.62",
     "@types/react": "17.0.38",
     "cypress": "9.2.0",
     "eslint-config-next": "12.0.7",
@@ -27,11 +29,21 @@
     "xo": "0.47.0"
   },
   "dependencies": {
+    "@apollo/client": "3.5.6",
     "@chakra-ui/react": "1.7.3",
     "@emotion/react": "11.7.1",
     "@emotion/styled": "11.6.0",
+    "@graphql-tools/schema": "8.3.1",
+    "@graphql-tools/stitch": "8.4.3",
+    "@graphql-tools/utils": "8.5.5",
+    "@graphql-tools/wrap": "8.3.2",
+    "apollo-server-express": "3.6.1",
+    "express": "4.17.2",
     "framer-motion": "5.5.5",
+    "graphql": "15.8.0",
+    "isomorphic-unfetch": "3.1.0",
     "next": "12.0.7",
+    "ramda": "0.27.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,15 @@
 import { AppProps } from 'next/app'
+import { ApolloProvider } from '@apollo/client'
 import { ChakraProvider } from '@chakra-ui/react'
+
+import { client } from '../graphql/client'
 
 export default function AppWrapper({ Component, pageProps }: AppProps) {
   return (
-    <ChakraProvider>
-      <Component {...pageProps} />
-    </ChakraProvider>
+    <ApolloProvider client={client}>
+      <ChakraProvider>
+        <Component {...pageProps} />
+      </ChakraProvider>
+    </ApolloProvider>
   )
 }

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -1,0 +1,47 @@
+import { NextApiHandler } from 'next'
+import { ApolloServer } from 'apollo-server-express'
+import { Router, Request, Response } from 'express'
+
+import { buildSchema } from '../../graphql/schema'
+
+const initialize = (async () => {
+  const schema = await buildSchema()
+  const server = new ApolloServer({
+    schema,
+  })
+
+  await server.start()
+
+  return server.getMiddleware({
+    path: '/api/graphql',
+  })
+})()
+
+const handler: NextApiHandler = async (request, response) => {
+  const apolloMiddleware = await initialize
+  await runMiddleware(request, response, apolloMiddleware)
+}
+
+export default handler
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+async function runMiddleware(
+  request: unknown,
+  response: unknown,
+  next: Router,
+) {
+  return new Promise((resolve, reject) => {
+    next(request as Request, response as Response, (result) => {
+      if (result instanceof Error) {
+        reject(result)
+      }
+
+      resolve(result)
+    })
+  })
+}

--- a/pages/countries.tsx
+++ b/pages/countries.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+import { CountriesTable } from '../components'
+
+type CountriesPageProps = Record<never, never>
+
+export const CountriesPage: React.FC<CountriesPageProps> = () => {
+  return <CountriesTable />
+}
+
+export default CountriesPage

--- a/pages/metrics.tsx
+++ b/pages/metrics.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+import { MetricTable } from '../components'
+
+type MetricsPageProps = Record<never, never>
+
+export const MetricsPage: React.FC<MetricsPageProps> = () => {
+  return <MetricTable />
+}
+
+export default MetricsPage

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './say-hello'
+export * from './set-cors-headers'

--- a/utils/set-cors-headers.test.ts
+++ b/utils/set-cors-headers.test.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage, ServerResponse } from 'http'
+import { setCorsHeaders } from './set-cors-headers'
+
+it('should set expected headers', () => {
+  const responsePre = new ServerResponse({} as IncomingMessage)
+
+  const responsePost = setCorsHeaders(responsePre)
+
+  expect(responsePost.getHeader('Access-Control-Allow-Credentials')).toBe(
+    'true',
+  )
+  expect(responsePost.getHeader('Access-Control-Allow-Origin')).toBe(
+    'https://studio.apollographql.com',
+  )
+  expect(responsePost.getHeader('Access-Control-Allow-Headers')).toBe(
+    'Origin, X-Requested-With, Content-Type, Accept',
+  )
+})

--- a/utils/set-cors-headers.ts
+++ b/utils/set-cors-headers.ts
@@ -1,0 +1,18 @@
+import { ServerResponse } from 'node:http'
+import { NextApiResponse } from 'next'
+
+export const setCorsHeaders = <T extends NextApiResponse | ServerResponse>(
+  response: T,
+): T => {
+  response.setHeader('Access-Control-Allow-Credentials', 'true')
+  response.setHeader(
+    'Access-Control-Allow-Origin',
+    'https://studio.apollographql.com',
+  )
+  response.setHeader(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Accept',
+  )
+
+  return response
+}

--- a/xo.config.cjs
+++ b/xo.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
     {
       files: '**/*.(spec|test).ts?(x)',
       rules: {
+        'unicorn/prefer-node-protocol': 0,
         '@typescript-eslint/no-unsafe-assignment': 0,
         '@typescript-eslint/no-unsafe-call': 0,
       },


### PR DESCRIPTION
### Changes

- [x] install dependencies
- [x] add specs w/ purpose of exercising graphql endpoint
- [x] setup GraphQL server
- [x] verify playground behavior
  - should be accessible when running dev
  - should not be accessible when _not_ dev
  - DX should be decent
- [x] setup Apollo client:
  - switch from stubbed metrics to via GraphQL
  - demonstrate type-safety + intellisense can be added to `useQuery`
- [x] stitch a remote schema
- [x] can we still get type-safety with remote schema
- [x] wrap in client-side only

---

Closes #86
